### PR TITLE
ci: create pr title check in actions

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -1,0 +1,25 @@
+name: titlecheck
+
+# Run on PR
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  titlecheck:
+    name: PR title follows coventional commit
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check conventinal title
+      uses: aslafy-z/conventional-pr-title-action@v2.2.5
+      with:
+        success-state: Title follows the specification.
+        failure-state: Title does not follow the specification.
+        context-name: conventional-pr-title
+        preset: conventional-changelog-angular@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to add an action for PR title check, to make sure we follow the commit conventions

