### PR TITLE
feat: Update contributor guide to include language from the template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,19 @@ This document will provide help on how to go about this. You can contribute in t
 * Suggesting features
 * Contributing code
 
+All contributions and project spaces are subject to our [Code of Conduct](https://github.com/fidelity/.github/blob/main/CODE_OF_CONDUCT.md).
+
 ## Reporting Bugs
 
 Reporting bugs is an essential part in making Theliv better for its end users.
 
-Bugs are reported using GitHub issues. A new **Bug Report** can be raised [here](https://github.com/fidelity/theliv/issues/new?assignees=&labels=kind%2Fbug&template=bug_report.md&title=).
+Please open an issue **unless** you are making a significant security disclosure. A new **Bug Report** can be raised [here](https://github.com/fidelity/theliv/issues/new?assignees=&labels=kind%2Fbug&template=bug_report.md&title=).
 
 When raising bugs please include as much information as possible including steps about how to reproduce the problem and what you expect the behavior to be.
+
+## How to disclose security concerns responsibly
+
+Please follow the instructions in our [security policy](https://github.com/fidelity/.github/blob/main/SECURITY.md) (also visible in the Security tab on the project's repo).
 
 ## Suggesting features
 
@@ -26,7 +32,11 @@ Include as much information as possible, understanding the problem that the feat
 
 ## Contributing Code
 
-Code contributions to Theliv are very welcome.
+Code contributions to Theliv are very welcome as long as you follow a few rules:
+
+* Your contribution must be received under the project's open source license.
+* You must have permission to make the contribution. We strongly recommend including a Signed-off-by line to indicate your adherence to the [Developer Certificate of Origin](https://developercertificate.org/).
+* All code contributions must be made via PR, and all checks must pass before merging.
 
 If you need a pointer on where to start you can look at the **good first issue** and **help wanted** issues:
 
@@ -46,3 +56,7 @@ Create a pull request
 Check that the PR checks pass
 
 Once a PR has been created it will be reviwed by one of the maintainers of Theliv.
+
+## Getting help
+
+If you have other questions about this project, please open an issue. To reach the Fidelity OSPO directly, please email [opensource@fmr.com](mailto:opensource@fmr.com).


### PR DESCRIPTION
Signed-off-by: Brian Warner <brian.warner2@fmr.com>

**What this PR does / why we need it**:
Fidelity is updating and standardizing our GitHub presence. This PR adds various guidelines from the default contributor guide.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A (governance related PR)
