### PR TITLE
fix: aggregate cluster level reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           echo "REPO=theliv" >> $GITHUB_ENV
           echo "using ${{ env.VERSION }} as the release version"
       - name: Login to GitHub Container Registry
-        if: github.event_name == 'push'
+        if: github.event_name == 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -41,5 +41,5 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           echo "REPO=theliv" >> $GITHUB_ENV
           echo "using ${{ env.VERSION }} as the release version"
       - name: Login to GitHub Container Registry
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -41,5 +41,5 @@ jobs:
         with:
           context: .
           file: ./build/Dockerfile
-          push: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/internal/problem/aggregate.go
+++ b/internal/problem/aggregate.go
@@ -42,28 +42,6 @@ func Aggregate(ctx context.Context, problems []Problem, client *kubeclient.KubeC
 	return cards, nil
 }
 
-// Build report card for cluster level or managed namespace level
-func buildClusterReportCard(ctx context.Context, p Problem) *ReportCard {
-	resources := []*ReportCardResource{}
-	var kind string
-	var rootCause *ReportCardIssue
-
-	res := getReportCardResource(ctx, p, p.AffectedResources)
-	resources = append(resources, res)
-	if rootCause == nil {
-		kind = p.AffectedResources.ResourceKind
-		rootCause = res.Issue
-	}
-	return &ReportCard{
-		Name:            p.Description,
-		Level:           p.Level,
-		Resources:       resources,
-		TopResourceType: kind,
-		ID:              hashcode(kind + "/" + p.Description),
-		RootCause:       rootCause,
-	}
-}
-
 func buildReportCards(ctx context.Context, problems []Problem, client *kubeclient.KubeClient) map[string]*ReportCard {
 	cards := make(map[string]*ReportCard)
 	for _, p := range problems {

--- a/pkg/service/detector.go
+++ b/pkg/service/detector.go
@@ -102,7 +102,7 @@ func DetectAlerts(ctx context.Context) (interface{}, error) {
 	}
 	log.SWithContext(ctx).Infof("Generated %d problem results", len(problemresults))
 
-	// Aggregator
+	// Convert problems to report cards
 	return problem.Aggregate(ctx, problemresults, client)
 }
 
@@ -121,6 +121,7 @@ func buildProblemsFromAlerts(alerts []v1.Alert) []*problem.Problem {
 	return problems
 }
 
+// Classifies problems as cluster or namespace level, filters all other problems.
 func filterProblems(ctx context.Context, problems []*problem.Problem, input *problem.DetectorCreationInput) []*problem.Problem {
 	thelivcfg := config.GetThelivConfig()
 	managednamespaces := thelivcfg.ProblemLevel.ManagedNamespaces


### PR DESCRIPTION
Theliv currently creates a cluster level report card for each affected resource.

Refactored code to treat as namespace level rc's, by grouping related resources under the same report card