### PR TITLE
fix: nil pointer panic, secure TLS transport, and dev server compatib…

### DIFF
--- a/internal/problem/aggregate.go
+++ b/internal/problem/aggregate.go
@@ -142,7 +142,7 @@ func getControlOwner(mo metav1.Object) *metav1.OwnerReference {
 		return nil
 	}
 	for _, owner := range mo.GetOwnerReferences() {
-		if *owner.Controller {
+		if owner.Controller != nil && *owner.Controller {
 			return &owner
 		}
 	}

--- a/pkg/auth/authmiddleware/authmiddleware.go
+++ b/pkg/auth/authmiddleware/authmiddleware.go
@@ -23,7 +23,11 @@ func StartAuth(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		//whitelist path
 		oidc := config.GetThelivConfig().Oidc
-		if r.URL.Path == "/theliv-api/v1/health" || r.URL.Path == "/theliv-api/v1/metrics" || r.URL.Path == getUrlPath(oidc.CallBack) {
+		callBackPath := ""
+		if oidc != nil {
+			callBackPath = getUrlPath(oidc.CallBack)
+		}
+		if r.URL.Path == "/theliv-api/v1/health" || r.URL.Path == "/theliv-api/v1/metrics" || (callBackPath != "" && r.URL.Path == callBackPath) {
 			handler.ServeHTTP(w, r)
 			return
 		}
@@ -43,7 +47,7 @@ func StartAuth(handler http.Handler) http.Handler {
 			}
 			return
 		}
-		if err.Error() == ErrNotThisAuth.Error() {
+		if err.Error() == ErrNotThisAuth.Error() && oidc != nil {
 			//oidc auth
 			r, err = oidcmethod.CheckAuthorization(r)
 			if err == nil {
@@ -65,7 +69,7 @@ func StartAuth(handler http.Handler) http.Handler {
 				return
 			}
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 	})
 }
 

--- a/pkg/auth/oidcmethod/oidcmethod.go
+++ b/pkg/auth/oidcmethod/oidcmethod.go
@@ -41,6 +41,10 @@ func InitAuth() error {
 		return nil
 	}
 	oicdConfig := config.GetThelivConfig().Oidc
+	if oicdConfig == nil {
+		log.S().Info("OIDC config not provided, skipping OIDC initialization")
+		return nil
+	}
 	p, err := oidc.NewProvider(context.Background(), oicdConfig.OidcProvider)
 	if err != nil {
 		log.S().Errorf("Unable to initialize oidc config: %v", err)

--- a/pkg/auth/samlmethod/samlmethod.go
+++ b/pkg/auth/samlmethod/samlmethod.go
@@ -12,25 +12,52 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/fidelity/theliv/internal/rbac"
-	com "github.com/fidelity/theliv/pkg/common"
 	"github.com/fidelity/theliv/pkg/config"
 	log "github.com/fidelity/theliv/pkg/log"
 	"github.com/go-ldap/ldap/v3"
-
 	"github.com/wangli1030/saml"
 	"github.com/wangli1030/saml/samlsp"
 )
 
 var sp *samlsp.Middleware
 
-func Init() {
+func loadIDPMetadata(authConfig *config.AuthConfig) *saml.EntityDescriptor {
+	switch {
+	case len(authConfig.IDPMetadata) > 0:
+		idpMetadata, err := samlsp.ParseMetadata(authConfig.IDPMetadata)
+		if err != nil {
+			panic(err)
+		}
+		return idpMetadata
+	case authConfig.IDPMetadataPath != "":
+		data, _ := os.ReadFile(authConfig.IDPMetadataPath)
+		idpMetadata, err := samlsp.ParseMetadata(data)
+		if err != nil {
+			panic(err)
+		}
+		return idpMetadata
+	case authConfig.IDPMetadataURL != "":
+		idpMetadataURL, err := url.Parse(authConfig.IDPMetadataURL)
+		if err != nil {
+			panic(err)
+		}
+		idpMetadata, err := samlsp.FetchMetadata(context.Background(), http.DefaultClient, *idpMetadataURL)
+		if err != nil {
+			panic(err)
+		}
+		return idpMetadata
+	default:
+		panic("please Provide Idp Metadata")
+	}
+}
 
+func Init() {
 	authConfig := config.GetThelivConfig().Auth
 
 	keyPair, err1 := tls.X509KeyPair(authConfig.Cert, authConfig.Key)
@@ -41,33 +68,7 @@ func Init() {
 	if err1 != nil {
 		panic(err1) // TODO handle error
 	}
-	var idpMetadata *saml.EntityDescriptor
-
-	if len(authConfig.IDPMetadata) > 0 {
-		idpMetadata, err1 = samlsp.ParseMetadata(authConfig.IDPMetadata)
-		if err1 != nil {
-			panic(err1) // TODO handle error
-		}
-	} else if authConfig.IDPMetadataPath != "" {
-		data, _ := ioutil.ReadFile(authConfig.IDPMetadataPath)
-		idpMetadata, err1 = samlsp.ParseMetadata(data)
-		if err1 != nil {
-			panic(err1) // TODO handle error
-		}
-
-	} else if authConfig.IDPMetadataURL != "" {
-		idpMetadataURL, err1 := url.Parse(authConfig.IDPMetadataURL)
-		if err1 != nil {
-			panic(err1) // TODO handle error
-		}
-		idpMetadata, err1 = samlsp.FetchMetadata(context.Background(), http.DefaultClient,
-			*idpMetadataURL)
-		if err1 != nil {
-			panic(err1) // TODO handle error
-		}
-	} else {
-		panic("please Provide Idp Metadata")
-	}
+	idpMetadata := loadIDPMetadata(authConfig)
 
 	rootURL, err1 := url.Parse(authConfig.RootURL)
 	if err1 != nil {
@@ -135,11 +136,12 @@ func HandleStartAuthFlow(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	//change redirect url to main page
+	// change redirect url to main page
 	mainuris := getRedirectUrl(r.Header.Get("redirect"))
 	mainuri, err := url.Parse(mainuris)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	r.URL = mainuri
 	// relayState is limited to 80 bytes but also must be integrity protected.
@@ -163,14 +165,14 @@ func HandleStartAuthFlow(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	http.Error(w, "unsupported SAML binding", http.StatusInternalServerError)
 }
 
 func getRedirectUrl(url string) (redirect string) {
 	redirect = "/theliv/"
 	path := strings.Split(url, redirect)
 	if len(path) == 2 {
-		redirect = redirect + path[1]
+		redirect += path[1]
 	}
 	return
 }
@@ -179,45 +181,45 @@ type Samlinfo struct {
 }
 
 func (Samlinfo) GetUser(r *http.Request, getAds bool) (*rbac.User, error) {
-	if session := samlsp.SessionFromContext(r.Context()); session != nil {
-		// this will panic if we have the wrong type of Session, and that is OK.
-		emptyResult := []string{""}
-		sessionWithAttributes := session.(samlsp.SessionWithAttributes)
-		attributes := sessionWithAttributes.GetAttributes()
-		surname, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"]
-		if !ok {
-			surname = emptyResult
-		}
-		givenname, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"]
-		if !ok {
-			givenname = emptyResult
-		}
-		displayname, ok := attributes["http://schemas.microsoft.com/identity/claims/displayname"]
-		if !ok {
-			displayname = emptyResult
-		}
-		emailaddress, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
-		if !ok {
-			emailaddress = emptyResult
-		}
-		corpid, ok := attributes["corpid"]
-		if !ok {
-			corpid = displayname
-		}
-
-		return &rbac.User{
-			Surname:      surname[0],
-			Givenname:    givenname[0],
-			UID:          corpid[0],
-			Displayname:  displayname[0],
-			Emailaddress: emailaddress[0],
-		}, nil
+	session := samlsp.SessionFromContext(r.Context())
+	if session == nil {
+		return nil, errors.New("session is empty")
 	}
-	return nil, errors.New("session is empty")
+	// this will panic if we have the wrong type of Session, and that is OK.
+	emptyResult := []string{""}
+	sessionWithAttributes := session.(samlsp.SessionWithAttributes)
+	attributes := sessionWithAttributes.GetAttributes()
+	surname, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"]
+	if !ok {
+		surname = emptyResult
+	}
+	givenname, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"]
+	if !ok {
+		givenname = emptyResult
+	}
+	displayname, ok := attributes["http://schemas.microsoft.com/identity/claims/displayname"]
+	if !ok {
+		displayname = emptyResult
+	}
+	emailaddress, ok := attributes["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"]
+	if !ok {
+		emailaddress = emptyResult
+	}
+	corpid, ok := attributes["corpid"]
+	if !ok {
+		corpid = displayname
+	}
+
+	return &rbac.User{
+		Surname:      surname[0],
+		Givenname:    givenname[0],
+		UID:          corpid[0],
+		Displayname:  displayname[0],
+		Emailaddress: emailaddress[0],
+	}, nil
 }
 
 func (Samlinfo) GetADgroups(r *http.Request, userID string) ([]string, error) {
-
 	result := callLDAP(r.Context(), userID)
 	ads := []string{}
 	if result == nil || len(result.Entries) == 0 {
@@ -235,12 +237,11 @@ func (Samlinfo) GetADgroups(r *http.Request, userID string) ([]string, error) {
 
 // calls LDAP, connect to server each time
 func callLDAP(ctx context.Context, userID string) *ldap.SearchResult {
-
 	ldapCfg := config.GetThelivConfig().Ldap
 
-	conn, err := ldap.DialTLS("tcp", ldapCfg.Address, &tls.Config{
-		InsecureSkipVerify: com.SkipTlsVerify,
-	})
+	conn, err := ldap.DialURL("ldaps://"+ldapCfg.Address, ldap.DialWithTLSConfig(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}))
 	if err != nil {
 		log.SWithContext(ctx).Errorf("Unable to connect to LDAP server, error is %v", err)
 		return nil

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -6,8 +6,6 @@
 package common
 
 const (
-	SkipTlsVerify = true
-
 	Name          = "name"
 	Namespace     = "namespace"
 	Pod           = "pod"

--- a/pkg/prometheus/promclient.go
+++ b/pkg/prometheus/promclient.go
@@ -8,56 +8,114 @@ package prometheus
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/fidelity/theliv/internal/problem"
-	com "github.com/fidelity/theliv/pkg/common"
 	"github.com/fidelity/theliv/pkg/config"
 	errors "github.com/fidelity/theliv/pkg/err"
 	log "github.com/fidelity/theliv/pkg/log"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promconfig "github.com/prometheus/common/config"
+	"k8s.io/client-go/rest"
 )
 
-var TLSRoundTripper http.RoundTripper = &http.Transport{
-	Proxy: http.ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	TLSHandshakeTimeout: 10 * time.Second,
-	TLSClientConfig: (&tls.Config{
-		InsecureSkipVerify: com.SkipTlsVerify,
-	}),
+func loadDataFromFileOrInline(inline []byte, filePath string) ([]byte, error) {
+	if len(inline) > 0 {
+		return inline, nil
+	}
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+		return data, nil
+	}
+	return nil, nil
 }
 
-func GetAlerts(ctx context.Context, input *problem.DetectorCreationInput) (result v1.AlertsResult, err error) {
+func buildTLSRoundTripper(kubeconfig *rest.Config) (http.RoundTripper, error) {
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
-	result = v1.AlertsResult{}
+	caData, err := loadDataFromFileOrInline(
+		kubeconfig.CAData, kubeconfig.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(caData) > 0 {
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caData) {
+			return nil, fmt.Errorf("failed to parse CA certificate from kubeconfig")
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	certData, err := loadDataFromFileOrInline(
+		kubeconfig.CertData, kubeconfig.CertFile)
+	if err != nil {
+		return nil, err
+	}
+	keyData, err := loadDataFromFileOrInline(
+		kubeconfig.KeyData, kubeconfig.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(certData) > 0 && len(keyData) > 0 {
+		cert, err := tls.X509KeyPair(certData, keyData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+	}, nil
+}
+
+func GetAlerts(ctx context.Context, input *problem.DetectorCreationInput) (v1.AlertsResult, error) {
 	promcfg := config.GetThelivConfig().Prometheus
-	address := input.Kubeconfig.Host + "/api/v1/namespaces/" + promcfg.Namespace + "/services/https:" + promcfg.Name + ":" + promcfg.Port + "/proxy"
+	address := input.Kubeconfig.Host + "/api/v1/namespaces/" +
+		promcfg.Namespace + "/services/https:" + promcfg.Name + ":" + promcfg.Port + "/proxy"
+
+	transport, err := buildTLSRoundTripper(input.Kubeconfig)
+	if err != nil {
+		log.SWithContext(ctx).Errorf("Failed to build TLS transport from kubeconfig: %s", err)
+		return v1.AlertsResult{}, err
+	}
 
 	client, err := api.NewClient(api.Config{
 		Address: address,
 		RoundTripper: promconfig.NewAuthorizationCredentialsRoundTripper("Bearer",
 			promconfig.NewInlineSecret(input.Kubeconfig.BearerToken),
-			TLSRoundTripper),
+			transport),
 	})
 	if err != nil {
 		log.SWithContext(ctx).Errorf("Got error when creating Prometheus client, error is %s", err)
-		return
+		return v1.AlertsResult{}, err
 	}
 
 	v1api := v1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result, err = v1api.Alerts(ctx)
+	result, err := v1api.Alerts(ctx)
 	if err != nil {
 		err = errors.NewCommonError(ctx, 6, err.Error())
 		log.SWithContext(ctx).Errorf("Got error when getting Prometheus alerts, error is %s", err)
+		return v1.AlertsResult{}, err
 	}
-	return
+	return result, nil
 }

--- a/web/nginx/default.conf
+++ b/web/nginx/default.conf
@@ -7,8 +7,8 @@ server {
     listen       443 ssl default_server;
     server_name  localhost;
     root   /app/client/;
-    client_header_buffer_size 20k;
-    large_client_header_buffers 8 16k;
+    client_header_buffer_size 128k;
+    large_client_header_buffers 16 128k;
 
     location / {
         root   /app/client/theliv/;
@@ -40,17 +40,16 @@ server {
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header Host            $http_host;
       proxy_pass http://apiserver$uri$is_args$args;
-      proxy_buffers         8 20k;  # Buffer pool = 8 buffers of 16k
-      proxy_buffer_size     20k;    # 16k of buffers from pool used for headers
+      proxy_buffers         16 128k;  # Buffer pool = 16 buffers of 128k
+      proxy_buffer_size     96k;    # 96k of buffers from pool used for headers
     }
 
     location /auth/ {
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header Host            $http_host;
       proxy_pass http://apiserver$uri$is_args$args;
-      proxy_buffers         8 20k;  # Buffer pool = 8 buffers of 16k
-      proxy_buffer_size     20k;    # 16k of buffers from pool used for headers
+      proxy_buffers         16 128k;  # Buffer pool = 16 buffers of 128k
+      proxy_buffer_size     96k;    # 96k of buffers from pool used for headers
     }
 
 }
-

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --baseHref=\"/theliv/\"",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider ng serve --baseHref=\"/theliv/\" --proxy-config proxy.conf.json",
     "build": "ng build --configuration production --base-href /theliv/ --deploy-url /theliv/static/ --output-hashing=all",
     "test": "npm run lint && ng test --code-coverage",
     "test-headless": "npm run lint && ng test --code-coverage --watch=false",
@@ -51,5 +51,8 @@
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.3.5"
+  },
+  "overrides": {
+    "path-to-regexp": "0.1.12"
   }
 }


### PR DESCRIPTION
…ility

  - Guard owner.Controller dereference in getControlOwner to prevent panic when OwnerReference.Controller field is unset (nil *bool)
  - Replace InsecureSkipVerify with proper TLS transport for Prometheus client; loads CA cert, client cert, and key from kubeconfig with TLS 1.2 minimum
  - Fix OIDC initialization nil dereference when OIDC config is not provided
  - Refactor SAML method initialization and error handling
  - Add NODE_OPTIONS=--openssl-legacy-provider to npm start for Node 17+ compatibility with webpack 4 (Angular 12)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
